### PR TITLE
feat: Pass kwargs to git.clone command to support parameters like 'de…

### DIFF
--- a/qubership_pipelines_common_library/v1/git_client.py
+++ b/qubership_pipelines_common_library/v1/git_client.py
@@ -39,7 +39,7 @@ class GitClient:
         self.branch = None  # last processed branch
         logging.info("Git Client configured for %s", self.host)
 
-    def clone(self, repo_path: str, branch: str, temp_path: str):
+    def clone(self, repo_path: str, branch: str, temp_path: str, **kwargs):
         """"""
         repo_path = repo_path.lstrip("/").rstrip("/")
         if not repo_path:
@@ -56,6 +56,7 @@ class GitClient:
             self._gen_repo_auth_url(self.host, self.username, self.password, self.repo_path),
             temp_path,
             branch=branch,
+            **kwargs
         )
 
     def commit_and_push(self, commit_message: str):

--- a/tests/clients/test_git_client.py
+++ b/tests/clients/test_git_client.py
@@ -30,8 +30,8 @@ class TestGitClientV1(unittest.TestCase):
     def test_clone_generates_correct_repo_url(self, clone_repo_mock):
         temp_path = "temp/repo_temp_dir"
         branch = "main"
-        self.client.clone("quber/tests", branch, temp_path)
-        clone_repo_mock.assert_called_with(f"https://{self.user}:{self.token}@git.qubership.org/quber/tests", temp_path, branch=branch)
+        self.client.clone("quber/tests", branch, temp_path, depth=1)
+        clone_repo_mock.assert_called_with(f"https://{self.user}:{self.token}@git.qubership.org/quber/tests", temp_path, branch=branch, depth=1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
…pth'
<!-- start messages -->
### Commit messages:
[LightlessOne](https://github.com/Netcracker/qubership-pipelines-common-python-library/commit/6698607b2e01be2ecdc2eaf878c5dde2e6b83034) feat: Pass kwargs to git.clone command to support parameters like 'depth'
<!-- end messages -->
