### PR TITLE
fix: Change k8s namespace existence check to a more common API call

### DIFF
--- a/qubership_pipelines_common_library/v1/kube_client.py
+++ b/qubership_pipelines_common_library/v1/kube_client.py
@@ -63,7 +63,7 @@ class KubeClient:
         if not namespace:
             return False
         try:
-            self.core_api.read_namespace_status(namespace)
+            self.core_api.read_namespace(namespace)
             return True
         except ApiException as e:
             if e.status == 404:


### PR DESCRIPTION
## Issue

Previous logic used get request for more uncommon resource - "namespace/status", new one requires get only on "namespace"

## Breaking Change?

- [ ] Yes
- [x] No

